### PR TITLE
Refactor one pair spec

### DIFF
--- a/spec/poker/hand_spec.rb
+++ b/spec/poker/hand_spec.rb
@@ -1,6 +1,8 @@
 require 'spec_helper'
 
 RSpec.describe Poker::Hand, type: :model do
+  let(:hand) { Poker::Hand.new(cards) }
+
   describe '#sets' do
     it 'places cards into their ranking slots' do
       cards = cyo_cards(3)
@@ -98,24 +100,34 @@ RSpec.describe Poker::Hand, type: :model do
   end
 
   describe '#one_pair?' do
-    let(:cards) { cyo_cards(2) }
-    let(:hand) { Poker::Hand.new(cards) }
+    subject { hand.one_pair? }
 
-    it 'returns true when there are two of the same rank' do
-      expect(hand.one_pair?).to be_truthy
+    context 'when there are two of the same rank' do
+      let(:cards) do
+        [
+          Poker::Card.new('2', 'Diamonds'),
+          Poker::Card.new('3', 'Diamonds'),
+          Poker::Card.new('4', 'Diamonds'),
+          Poker::Card.new('5', 'Diamonds'),
+          Poker::Card.new('2', 'Clubs'),
+        ]
+      end
+
+      it { is_expected.to be_truthy }
     end
 
-    it 'returns false when there are not two of the same rank' do
-      cards = cyo_cards(3)
-      hand = Poker::Hand.new(cards)
+    context 'when there are not two of the same rank' do
+      let(:cards) do
+        [
+          Poker::Card.new('2', 'Diamonds'),
+          Poker::Card.new('3', 'Diamonds'),
+          Poker::Card.new('4', 'Diamonds'),
+          Poker::Card.new('5', 'Diamonds'),
+          Poker::Card.new('6', 'Clubs'),
+        ]
+      end
 
-      expect(hand.one_pair?).to be_falsey
-    end
-
-    it 'receives of_a_kind?' do
-      expect(hand).to receive(:of_a_kind?)
-
-      hand.one_pair?
+      it { is_expected.to be_falsey }
     end
   end
 


### PR DESCRIPTION
This refactors the one pair spec to remove a random failure caused by
the generated card set occasionally having a pair (approx. one of out
every 13 tries) and removes the reliance on the `cyo_cards` method.

We're going to do this refactoring on some of the other tests soon.